### PR TITLE
Disconnectable Links

### DIFF
--- a/runsc/boot/network.go
+++ b/runsc/boot/network.go
@@ -314,6 +314,7 @@ func (n *Network) CreateLinksAndRoutes(args *CreateLinksAndRoutesArgs, _ *struct
 				GvisorGSOEnabled:   link.GvisorGSOEnabled,
 				TXChecksumOffload:  link.TXChecksumOffload,
 				RXChecksumOffload:  link.RXChecksumOffload,
+				DisconnectOk:       true,
 			})
 			if err != nil {
 				return err
@@ -406,6 +407,7 @@ func (n *Network) CreateLinksAndRoutes(args *CreateLinksAndRoutesArgs, _ *struct
 			RXChecksumOffload: link.RXChecksumOffload,
 			InterfaceIndex:    link.InterfaceIndex,
 			Bind:              link.Bind == BindSentry,
+			DisconnectOk:      true,
 		})
 		if err != nil {
 			return err


### PR DESCRIPTION
Make the default setting for fd-based and xdp-based links default to 'disconnectable'

Newly created links (whether fd-based or xdp-based) have options that indicate whether they are disconnectable, meaning that either the sandboxed application or the host system can close or terminate the communication channel.

By default, this is set to False, meaning that when TCP connections are established within a sandbox, and a runsc checkpoint is called, the kernel panics and throws (see `pkg/tcpip/transport/tcp/endpoint_state.go`, line 44). In general, this is a sensible thing to do since the connections cannot be saved.

However, if you wish to simply drop these connections when calling a runsc checkpoint, you are happy to simply have the SaveRestore option set to `false`, but the DisconnectOk option set to `true`.

We set these flags in the runsc/boot/network.go file, in the CreateLinksAndRoutes function that should only be called once. This is probably preferable to hardcoding the capability to true in fdbased/endpoint.go and xdp/endpoint.go.

For more context on how this approach was determined see: https://github.com/google/gvisor/issues/113